### PR TITLE
Initialize SQLite database and remove ObjectBox usage

### DIFF
--- a/lib/database/database_helper.dart
+++ b/lib/database/database_helper.dart
@@ -1,0 +1,40 @@
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:sqflite/sqflite.dart';
+
+/// Simple SQLite helper used during migration away from ObjectBox.
+class DatabaseHelper {
+  static Database? _db;
+
+  /// Initialize the database and create required tables if they do not exist.
+  static Future<void> initialize() async {
+    final docsDir = await getApplicationDocumentsDirectory();
+    final dbPath = join(docsDir.path, 'next_movie', 'app.db');
+    _db = await openDatabase(
+      dbPath,
+      version: 1,
+      onCreate: (db, version) async {
+        await db.execute('''
+          CREATE TABLE IF NOT EXISTS movies (
+            id INTEGER PRIMARY KEY,
+            title TEXT,
+            path TEXT,
+            cover TEXT
+          )
+        ''');
+      },
+    );
+  }
+
+  /// Update cover path for a movie.
+  static Future<void> updateMovieCover(int id, String coverPath) async {
+    final db = _db;
+    if (db == null) return;
+    await db.update(
+      'movies',
+      {'cover': coverPath},
+      where: 'id = ?',
+      whereArgs: [id],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
-import 'package:next_movie/objectbox/objectbox.dart';
+import 'package:next_movie/database/database_helper.dart';
 import 'package:next_movie/task/task_queue.dart';
 import 'package:next_movie/ui/page/home_page.dart';
 import 'package:path/path.dart';
@@ -41,8 +41,8 @@ Future<void> main() async {
   } else {
     logger.info('文件夹已存在: ${settingFolder.path}');
   }
-  // 初始化 ObjectBoxProvider
-  await ObjectBox.initialize();
+  // 初始化 SQLite 数据库
+  await DatabaseHelper.initialize();
 
   runApp(
     MultiProvider(

--- a/lib/service/movie_service/thumbnail_task.dart
+++ b/lib/service/movie_service/thumbnail_task.dart
@@ -2,10 +2,9 @@ import 'dart:io';
 
 import 'package:fc_native_video_thumbnail/fc_native_video_thumbnail.dart';
 import 'package:logging/logging.dart';
-import 'package:next_movie/model/movie.dart';
-import 'package:next_movie/objectbox/objectbox.dart';
 import 'package:next_movie/task/task_queue.dart';
 import 'package:next_movie/utils/app_path.dart';
+import 'package:next_movie/database/database_helper.dart';
 import 'package:path/path.dart';
 
 class AddThumbnailTask {
@@ -44,14 +43,7 @@ class AddThumbnailTask {
               quality: 90);
           if (thumbnailGenerated) {
             _logger.info('Thumbnail for $_movieId generated');
-            final box = ObjectBox.getBox<Movie>();
-            final movie = box.get(_movieId);
-            if (movie == null) {
-              _logger.warning('Movie $_movieId not found');
-              return;
-            }
-            movie.cover = [path];
-            box.put(movie);
+            await DatabaseHelper.updateMovieCover(_movieId, path);
           } else {
             _logger.warning('Thumbnail for $_movieId not generated');
           }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,7 @@ dependencies:
   provider: ^6.1.2
   fc_native_video_thumbnail: ^0.17.2
   path: ^1.9.0
+  sqflite: ^2.3.0
   logging: ^1.3.0
   media_info: ^0.12.0+2
   tdesign_flutter: ^0.1.0


### PR DESCRIPTION
## Summary
- replace ObjectBox initialization with SQLite-based DatabaseHelper
- update thumbnail task to persist cover path via SQLite
- add sqflite dependency and basic database helper

## Testing
- `dart format lib/main.dart lib/database/database_helper.dart lib/service/movie_service/thumbnail_task.dart pubspec.yaml` *(command not found: dart)*
- `flutter analyze` *(command not found: flutter)*


------
https://chatgpt.com/codex/tasks/task_e_68994f6ffdf88329bcd05a7582eff72d